### PR TITLE
Fixed #!/bin/node and updated README

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,9 @@ node install -g @gauravnumber/move
 
 ## Usage
 
+```
 move <source_path> <destination_path>
+```
 
 ## Example
 

--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@
 ![GitHub tag (latest SemVer)](https://img.shields.io/github/v/tag/gauravnumber/move.js)
 ![Twitter Follow](https://img.shields.io/twitter/follow/gauravnumber?style=social)
 
-`mv` command does not support adding index when file exists so I create `move`.
+`mv` command doesn't support renaming file (adding an index/number) when file already exists, so I created `move`.
 
-`move` didn't have any dependencies.
+`move` doesn't have any dependencies.
 
 ## Install
 
@@ -14,9 +14,13 @@
 node install -g @gauravnumber/move
 ```
 
+## Usage
+
+move <source_path> <destination_path>
+
 ## Example
 
-Folder Structure
+Initial Folder Structure
 
 ```
 .
@@ -28,13 +32,13 @@ Folder Structure
 └── 6.txt
 ```
 
-Type below command.
+Execute the command below
 
 ```
 move 1.txt 2.txt
 ```
 
-`2.txt` file already exists. `move` command append index on the file. After running above command. Folder structure looks like this.
+`2.txt` file already exists, so `move` appends an index to the filename. After running above command, the folder structure looks like this.
 
 ```
 .

--- a/move
+++ b/move
@@ -1,4 +1,4 @@
-#!/bin/node
+#!/usr/bin/env node
 const fs = require('fs')
 const path = require('path')
 


### PR DESCRIPTION
This command did not to run on my system, and it gave the error `zsh: /opt/homebrew/bin/move: bad interpreter: /bin/node: no such file or directory`. I use an M1 Apple Silicon Macbook and use homebrew, so node.js is located at /opt/homebrew/bin/node. I replaced the hard path of `/bin/node` with `/usr/bin/env node`, which uses the user's $PATH variable to determine node's location.

I also fixed some grammar mistakes in the README.